### PR TITLE
Fix: avoid docker cache for apt update

### DIFF
--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -1,18 +1,16 @@
 FROM ubuntu:16.04
 MAINTAINER Harish Anand "https://github.com/harishanand95"
 
+ARG CACHEBUST=1
 RUN apt-get update
 RUN apt-get install locales
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LC_CTYPE en_US.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
-
 RUN apt-get install -y openssh-server sudo
 RUN apt-get install -y python nano vim
 RUN mkdir /var/run/sshd
-ARG CACHEBUST=1
-
 RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config


### PR DESCRIPTION
* using docker cache to `apt update` command can result in missing new ubuntu repo's IP address