### PR TITLE
Fix: pushpin fails in screen daemon

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -702,3 +702,6 @@
   - include: tasks/create_user.yml
   - include: tasks/add_local_repository.yml
   - include: tasks/update_repos.yml
+
+  - name: Install tmux
+    apt: name=tmux state=present

--- a/tasks/pushpin/start_pushpin.yml
+++ b/tasks/pushpin/start_pushpin.yml
@@ -1,3 +1,3 @@
 ---
   - name: Start pushpin
-    command: screen -dm pushpin --config /root/pushpin/pushpin.conf --logfile pushpin_log_file
+    command: tmux new-session -d 'pushpin --config /root/pushpin/pushpin.conf --logfile pushpin_log_file'


### PR DESCRIPTION
This issue was reported during the setup in Electronic City, Bangalore. A easy fix is to use tmux instead of screen.
cc: @swaminathanvasanth 